### PR TITLE
Change continue shopping link to yoast.com

### DIFF
--- a/php/functions-links.php
+++ b/php/functions-links.php
@@ -155,7 +155,7 @@ function author_has( $social_site ) {
  * @return string
  */
 function url_shop_page() {
-	return home_url( 'shop/' );
+	return 'https://yoast.com/shop/';
 }
 
 /**


### PR DESCRIPTION
I've only found the shoplink in the checkout process.