### PR TITLE
Use my.yoast for cart content indicator

### DIFF
--- a/php/class-domains.php
+++ b/php/class-domains.php
@@ -56,7 +56,7 @@ class Domains {
 				return $domain . '/shop/';
 
 			case 'shop_counter_ajax':
-				$domain = apply_filters( 'yoast:domain', 'yoast.com' );
+				$domain = apply_filters( 'yoast:domain', 'my.yoast.com' );
 
 				return $domain . '/wp-admin/admin-ajax.php';
 

--- a/php/class-domains.php
+++ b/php/class-domains.php
@@ -41,7 +41,7 @@ class Domains {
 				return $domain . '/wordpress/plugins/';
 
 			case 'checkout':
-				$domain = apply_filters( 'yoast:domain', 'yoast.com' );
+				$domain = apply_filters( 'yoast:domain', 'my.yoast.com' );
 
 				return $domain . '/checkout/';
 
@@ -51,7 +51,7 @@ class Domains {
 				return $domain . '/newsletter/';
 
 			case 'shop':
-				$domain = apply_filters( 'yoast:domain', 'yoast.com' );
+				$domain = apply_filters( 'yoast:domain', 'my.yoast.com' );
 
 				return $domain . '/shop/';
 

--- a/php/class-domains.php
+++ b/php/class-domains.php
@@ -51,7 +51,7 @@ class Domains {
 				return $domain . '/newsletter/';
 
 			case 'shop':
-				$domain = apply_filters( 'yoast:domain', 'my.yoast.com' );
+				$domain = apply_filters( 'yoast:domain', 'yoast.com' );
 
 				return $domain . '/shop/';
 


### PR DESCRIPTION
changes the ajaxURL to my.yoast instead of yoast.com.
fixes https://github.com/Yoast/my.yoast.com/issues/13
⚠️ Merge(/push to production) during the my.yoast migration process ⚠️ 