### PR TITLE
Includes hook for Google Tag Manager

### DIFF
--- a/php/class-theme.php
+++ b/php/class-theme.php
@@ -47,7 +47,7 @@ class Theme {
 
 		add_action( 'widgets_init', array( $this, 'register_widgets' ) );
 
-        add_action( 'yst_body_open', array( $this, 'add_google_tag_manager' ) );
+		add_action( 'yst_body_open', array( $this, 'add_google_tag_manager' ) );
 
 		add_filter( 'site_icon_meta_tags', array( $this, 'site_icons' ) );
 
@@ -273,16 +273,16 @@ class Theme {
 		register_widget( __NAMESPACE__ . '\\Social_Widget' );
 	}
 
-    /**
-     * Adds the google tag manager to the body.
-     */
-    public function add_google_tag_manager() {
-        if ( function_exists( 'gtm4wp_the_gtm_tag' ) ) {
-            gtm4wp_the_gtm_tag();
-        }
-    }
+	/**
+	 * Adds the google tag manager to the body.
+	 */
+	public function add_google_tag_manager() {
+		if ( function_exists( 'gtm4wp_the_gtm_tag' ) ) {
+			gtm4wp_the_gtm_tag();
+		}
+	}
 
-    /**
+	/**
 	 * Adds all theme support to WordPress
 	 */
 	public function after_setup_theme() {

--- a/php/class-theme.php
+++ b/php/class-theme.php
@@ -47,6 +47,8 @@ class Theme {
 
 		add_action( 'widgets_init', array( $this, 'register_widgets' ) );
 
+        add_action( 'yst_body_open', array( $this, 'add_google_tag_manager' ) );
+
 		add_filter( 'site_icon_meta_tags', array( $this, 'site_icons' ) );
 
 		add_filter( 'comments_template_query_args', array( $this, 'reverse_comments_order' ) );
@@ -271,7 +273,16 @@ class Theme {
 		register_widget( __NAMESPACE__ . '\\Social_Widget' );
 	}
 
-	/**
+    /**
+     * Adds the google tag manager to the body.
+     */
+    public function add_google_tag_manager() {
+        if ( function_exists( 'gtm4wp_the_gtm_tag' ) ) {
+            gtm4wp_the_gtm_tag();
+        }
+    }
+
+    /**
 	 * Adds all theme support to WordPress
 	 */
 	public function after_setup_theme() {


### PR DESCRIPTION
This hook allows the Google Tag Manager script to be put directly into the body, that is the best place for this script. 

After this is merged, in the Google Tag Manager plugin settings, the container placement can be set to custom. 