### PR TITLE
Implement check for custom set URLs in development

### DIFF
--- a/php/class-domains.php
+++ b/php/class-domains.php
@@ -112,10 +112,10 @@ class Domains {
 	 */
 	private function get_development_domains() {
 		return [
-			'yoast.com'     => 'http://yoast.dev',
-			'kb.yoast.com'  => 'http://kb.yoast.dev',
-			'my.yoast.com'  => 'http://my.yoast.dev',
-			'yoast.academy' => 'http://yoast.academy.dev',
+			'yoast.com'     => defined( 'YOAST_COM_DEV_BASEURL' ) ? YOAST_COM_DEV_BASEURL : 'http://yoast.dev',
+			'kb.yoast.com'  => defined( 'KB_YOAST_DEV_BASEURL' ) ? KB_YOAST_DEV_BASEURL : 'http://kb.yoast.dev',
+			'my.yoast.com'  => defined( 'MY_YOAST_DEV_BASEURL' ) ? MY_YOAST_DEV_BASEURL : 'http://my.yoast.dev',
+			'yoast.academy' => defined( 'YOAST_ACADEMY_DEV_BASEURL' ) ? YOAST_ACADEMY_DEV_BASEURL : 'http://yoast.academy.dev',
 		];
 	}
 


### PR DESCRIPTION
In order to let VVV and YYY vagrant boxes coexist (for a better workflow when developing i.e. Academy and My Yoast), it would be preferable to be able to set custom URLs. 
In the current situation for example `yoast.dev` has a different ip-address in both the VVV and YYY environments, which can be problematic. Thus, it would be nice to be able to set a custom URL (i.e. `yoast.yyy.dev`) in one of the environments. 

In `class-domains.php`, we should check whether such a URL is set, and if it is not set, use the default development URLs.

To test, set a custom url in the environment wp-config like so:
```php
// Set custom development URLs.
define( 'YOAST_COM_DEV_BASEURL', 'CUSTOM URL HERE' );
define( 'MY_YOAST_DEV_BASEURL', 'CUSTOM URL HERE' );
define( 'KB_YOAST_DEV_BASEURL', 'CUSTOM URL HERE' );
define( 'YOAST_ACADEMY_DEV_BASEURL', 'CUSTOM URL HERE' );
```