### PR TITLE
Show current grade instead of best grade in the results graph

### DIFF
--- a/lifterlms/quiz/results.php
+++ b/lifterlms/quiz/results.php
@@ -19,7 +19,6 @@ if ( ! $quiz->get_total_attempts_by_user( $user_id ) ) {
 }
 
 $grade      = $quiz->get_user_grade( $user_id );
-$best_grade = $quiz->get_best_grade( $user_id );
 
 $quiz->is_passing_score( $user_id, $grade );
 $passing_percent = $quiz->get_passing_percent();
@@ -36,12 +35,9 @@ $is_passing_score = $quiz->is_passing_score( $user_id, $grade );
 
 		<?php
 		//determine if grade, best grade or none should be shown.
-		if ( isset( $grade ) && isset( $best_grade ) ) :
-
-			$graph_grade = empty( $grade ) ? $best_grade : $grade;
-
-			?>
-			<input type="hidden" id="llms-grade-value" name="llms_grade" value="<?php echo $graph_grade; ?>"/>
+		if ( isset( $grade ) ) :
+            ?>
+			<input type="hidden" id="llms-grade-value" name="llms_grade" value="<?php echo $grade; ?>"/>
 			<div class="llms-progress-circle">
 				<svg>
 					<g>
@@ -54,8 +50,7 @@ $is_passing_score = $quiz->is_passing_score( $user_id, $grade );
 						<circle cx="40" cy="40" r="63" transform="translate(50,50)"/>
 					</g>
 				</svg>
-
-				<div class="llms-progress-circle-count"><?php printf( __( '%s%%' ), $graph_grade ); ?></div>
+				<div class="llms-progress-circle-count"><?php printf( __( '%s%%' ), $grade ); ?></div>
 			</div>
 
 		<?php endif; ?>


### PR DESCRIPTION
Fixes https://github.com/Yoast/yoast.academy/issues/69

This PR makes sure the grade from the current quiz-round is shown, instead of the best achieved results from the user. Because best_grade isn't used in the file anymore, I removed the whole `$best_grade` variable. 

In https://github.com/Yoast/yoast.academy/issues/69#issuecomment-321235371 , @JesseYoast shows that the results sometimes shows an 200% score. I haven't been able to reproduce this. This could be an unrelated issue. If we detect this behaviour in the future, we should open a new issue for this. 