### PR TITLE
Updated activation mail templates and added course title

### DIFF
--- a/html_includes/emails/academy-invite.php
+++ b/html_includes/emails/academy-invite.php
@@ -3,11 +3,15 @@
 namespace Yoast\YoastCom\Theme;
 
 ?>
-Thank you for buying a Yoast Academy course!
+Thank you for buying the <?php echo $template_args['title']; ?>!
 
-If you already have a Yoast Academy account, the course you bought is now accessible in <a href="https://yoast.academy/my-courses/">My academy</a>.
-
-If you are new to Yoast Academy, <a href="<?php echo esc_url( $template_args['url'] ); ?>">click here to create an account</a>.
+All that's left now is activating your course.
+<ol>
+    <li><a href="<?php echo esc_url( $template_args['url'] ); ?>">Click this link.</a></li>
+    <li>Login or create an account.</li>
+    <li>Activate your course by clicking the button.</li>
+    <li>Your course is now available in <a href="https://yoast.academy/my-courses/">My Academy</a>.</li>
+</ol>
 
 If you cannot click on the link, paste this url in your browser: <?php echo esc_url( $template_args['url'] ); ?>
 

--- a/html_includes/emails/academy-invite.php
+++ b/html_includes/emails/academy-invite.php
@@ -9,7 +9,7 @@ All that's left now is activating your course.
 <ol>
     <li><a href="<?php echo esc_url( $template_args['url'] ); ?>">Click this link.</a></li>
     <li>Login or create an account.</li>
-    <li>Activate your course by clicking the button.</li>
+    <li>Activate your course by clicking the button 'Add <?php echo $template_args['title']; ?> to this account'.</li>
     <li>Your course is now available in <a href="https://yoast.academy/my-courses/">My Academy</a>.</li>
 </ol>
 

--- a/html_includes/emails/academy-order-invite.php
+++ b/html_includes/emails/academy-order-invite.php
@@ -9,7 +9,7 @@ All that's left now is activating your course.
 <ol>
     <li><a href="<?php echo esc_url( $template_args['url'] ); ?>">Click this link.</a></li>
     <li>Login or create an account.</li>
-    <li>Activate your course by clicking the button.</li>
+    <li>Activate your course by clicking the button 'Add <?php echo $template_args['title']; ?> to this account'.</li>
     <li>Your course is now available in <a href="https://yoast.academy/my-courses/">My Academy</a>.</li>
 </ol>
 

--- a/html_includes/emails/academy-order-invite.php
+++ b/html_includes/emails/academy-order-invite.php
@@ -3,11 +3,15 @@
 namespace Yoast\YoastCom\Theme;
 
 ?>
-Thank you for buying our Yoast Academy courses!
+Thank you for buying the <?php echo $template_args['title']; ?>!
 
-If you already have a Yoast Academy account, the courses you bought are now accessible in <a href="https://yoast.academy/my-courses/">My academy</a>. From there you can manage your course invites.
-
-If you are new to Yoast Academy, <a href="<?php echo esc_url( $template_args['url'] ); ?>">click here to create an account</a>.
+All that's left now is activating your course.
+<ol>
+    <li><a href="<?php echo esc_url( $template_args['url'] ); ?>">Click this link.</a></li>
+    <li>Login or create an account.</li>
+    <li>Activate your course by clicking the button.</li>
+    <li>Your course is now available in <a href="https://yoast.academy/my-courses/">My Academy</a>.</li>
+</ol>
 
 If you cannot click on the link, paste this url in your browser: <?php echo esc_url( $template_args['url'] ); ?>
 


### PR DESCRIPTION
This PR updates the copy of the template of the course activation email, as requested in https://github.com/Yoast/yoast.academy/issues/54

To test, make sure to also checkout the branch `54-horrible-registration-activation-email-for-training course`, which introduces the `title`-variable that is used in this PR.

Fixes #https://github.com/Yoast/yoast.academy/issues/54
