### PR TITLE
removed hire-us menuitem

### DIFF
--- a/php/class-color-scheme.php
+++ b/php/class-color-scheme.php
@@ -18,7 +18,6 @@ class Color_Scheme {
 	const PLUGINS = 'theme-plugins';
 	const COURSES = 'theme-courses';
 	const EBOOKS = 'theme-ebooks';
-	const HIRE_US = 'theme-hire-us';
 	const FAQ = 'theme-faq';
 
 	/**
@@ -57,7 +56,6 @@ class Color_Scheme {
 			Menu_Structure::PLUGINS_TYPE  => self::PLUGINS,
 			Menu_Structure::COURSES_TYPE  => self::COURSES,
 			Menu_Structure::EBOOKS_TYPE   => self::EBOOKS,
-			Menu_Structure::HIRE_US_TYPE  => self::HIRE_US,
 			Menu_Structure::FAQ_TYPE      => self::FAQ,
 		];
 

--- a/php/class-page-menu-type.php
+++ b/php/class-page-menu-type.php
@@ -9,7 +9,6 @@ class Page_Menu_Type {
 	const PLUGINS = 'plugins';
 	const COURSES = 'courses';
 	const EBOOKS = 'ebooks';
-	const HIRE_US = 'hire-us';
 	const FAQ = 'faq';
 
 	/**
@@ -41,7 +40,6 @@ class Page_Menu_Type {
 				self::PLUGINS  => __( 'Plugins', 'yoastcom' ),
 				self::COURSES  => __( 'Courses', 'yoastcom' ),
 				self::EBOOKS   => __( 'eBooks', 'yoastcom' ),
-				self::HIRE_US  => __( 'Hire us', 'yoastcom' ),
 				self::FAQ      => __( 'FAQ', 'yoastcom' ),
 			),
 		) );


### PR DESCRIPTION
Removed all code involving the menu item "hire-us".

Goes along with: https://github.com/Yoast/website-menu-structure/pull/20

How to test:
Apply both branches. This is key!

Issues with testing:
First, I have applied it directly to master and the changes were successful. After resetting the changes and making a branch together with @terw-dan, we can no longer test it.