### PR TITLE
Fixes product icons on plugin archive

### DIFF
--- a/php/functions-helpers.php
+++ b/php/functions-helpers.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\YoastCom\Theme;
 
+use Yoast\YoastCom\Core\WordPress\Integration\BC\Migration_Utils;
 use Yoast\YoastCom\RemoteCheckout\Remote_Product;
 
 /**
@@ -365,15 +366,24 @@ function get_product_icon( $product_id = null, $diapositive = false ) {
 		$icon_key = 'icon_diapositive';
 	}
 
+
 	// If we find the icon just return it.
 	if ( get_post_meta( $product_id, $icon_key, true ) ) {
 		$icon = get_post_meta( $product_id, $icon_key, true );
-	} // If there is a connected download_id, try to get it's icon.
-	elseif ( $download_id = get_post_meta( $product_id, 'download_id', true ) ) {
-		$icon = get_product_icon( $download_id, $diapositive );
-	} // If there is a connected premium product, try to get it's icon.
-	elseif ( $premium_id = get_post_meta( $product_id, 'connected_premium_plugin', true ) ) {
-		$icon = get_product_icon( $premium_id, $diapositive );
+
+		// If there is a connected woocommerce product, try to get its icon.
+	} elseif ( $woo_product_id = get_post_meta( $product_id, 'product_id', true ) ) {
+		$icon = get_product_icon( $woo_product_id, $diapositive );
+
+		// If there is a connected download_id, try to get its icon.
+	} elseif ( $download_id = get_post_meta( $product_id, 'download_id', true ) ) {
+		$download_id = Migration_Utils::Products()->lookup( $download_id );
+		$icon        = get_product_icon( $download_id, $diapositive );
+
+		// If there is a connected premium product, try to get its icon.
+	} elseif ( $premium_id = get_post_meta( $product_id, 'connected_premium_plugin', true ) ) {
+		$product_id = Migration_Utils::Products()->lookup( $product_id );
+		$icon       = get_product_icon( $product_id, $diapositive );
 	}
 
 	if ( '' === $icon && class_exists( 'Yoast\YoastCom\RemoteCheckout\Remote_Product' ) ) {

--- a/php/functions-helpers.php
+++ b/php/functions-helpers.php
@@ -371,7 +371,7 @@ function get_product_icon( $product_id = null, $diapositive = false ) {
 	if ( get_post_meta( $product_id, $icon_key, true ) ) {
 		$icon = get_post_meta( $product_id, $icon_key, true );
 
-		// If there is a connected woocommerce product, try to get its icon.
+		// If there is a connected WooCommerce product, try to get its icon.
 	} elseif ( $woo_product_id = get_post_meta( $product_id, 'product_id', true ) ) {
 		$icon = get_product_icon( $woo_product_id, $diapositive );
 
@@ -379,11 +379,6 @@ function get_product_icon( $product_id = null, $diapositive = false ) {
 	} elseif ( $download_id = get_post_meta( $product_id, 'download_id', true ) ) {
 		$download_id = Migration_Utils::Products()->lookup( $download_id );
 		$icon        = get_product_icon( $download_id, $diapositive );
-
-		// If there is a connected premium product, try to get its icon.
-	} elseif ( $premium_id = get_post_meta( $product_id, 'connected_premium_plugin', true ) ) {
-		$product_id = Migration_Utils::Products()->lookup( $product_id );
-		$icon       = get_product_icon( $product_id, $diapositive );
 	}
 
 	if ( '' === $icon && class_exists( 'Yoast\YoastCom\RemoteCheckout\Remote_Product' ) ) {


### PR DESCRIPTION
on http://yoast.dev/wordpress/plugins/

Old:
<img width="407" alt="yoast_plugins_archive_-_yoast" src="https://user-images.githubusercontent.com/5352634/30109308-30042e16-9306-11e7-83ff-dac463981aa7.png">

New:
<img width="553" alt="yoast_plugins_archive_-_yoast" src="https://user-images.githubusercontent.com/5352634/30109287-196ab5d0-9306-11e7-85e3-19aa6394d798.png">
