### PR TITLE
Don't show errors when there is no description for a question

### DIFF
--- a/lifterlms/quiz/summary.php
+++ b/lifterlms/quiz/summary.php
@@ -83,7 +83,7 @@ $quiz_data = get_user_meta( $user_id, 'llms_quiz_data', true );
 
 								<?php
 
-								if ( $options[ $question['answer'] ]['option_text'] !== $correct_option['option_text'] && $quiz->show_correct_answer() ) {
+								if ( ( ! isset( $options[ $question['answer'] ] ) || $options[ $question['answer'] ]['option_text'] !== $correct_option['option_text'] ) && $quiz->show_correct_answer() ) {
 									echo '<li><span class="llms-quiz-summary-label correct-answer">';
 									echo '<strong class="answer_correct">Correct answer:</strong><br>' . wp_kses_post( $correct_option['option_text'] );
 									echo '</span></li>';

--- a/lifterlms/quiz/summary.php
+++ b/lifterlms/quiz/summary.php
@@ -65,7 +65,7 @@ $quiz_data = get_user_meta( $user_id, 'llms_quiz_data', true );
 							<div class="clear"></div>
 
 							<ul>
-								<?php if ( array_key_exists( 'option_text', $options[ $question['answer'] ] ) ) { ?>
+								<?php if ( isset( $options[ $question['answer'] ] ) && array_key_exists( 'option_text', $options[ $question['answer'] ] ) ) { ?>
 
 									<li>
 										<span class="llms-quiz-summary-label user-answer">
@@ -89,22 +89,18 @@ $quiz_data = get_user_meta( $user_id, 'llms_quiz_data', true );
 									echo '</span></li>';
 								}
 
-								if ( $question['correct'] ) {
-									if ( $quiz->show_description_right_answer() ) {
-										if ( array_key_exists( 'option_description', $options[ $question['answer'] ] ) ) {
-											echo '<li><span class="llms-quiz-summary-label clarification">' .
-                                                __( '<strong class="answer_clarification">Clarification:</strong><br>' . wpautop( $options[ $question['answer'] ]['option_description'] ) )
-											     . '</span></li>';
-										}
-									}
-								}
-								else {
-									if ( $quiz->show_description_wrong_answer() ) {
-										if ( array_key_exists( 'option_description', $options[ $question['answer'] ] ) ) {
-											echo '<li><span class="llms-quiz-summary-label clarification">' .
-                                                __( '<strong class="answer_clarification">Clarification:</strong><br>' . wpautop( $options[ $question['answer'] ]['option_description'] ) )
-											     . '</span></li>';
-										}
+								if (
+									isset( $options[ $question['answer'] ] ) &&
+									! empty( trim( $options[ $question['answer'] ]['option_description'] ) ) &&
+									array_key_exists( 'option_description', $options[ $question['answer'] ] )
+								) {
+									if ( ( $question['correct'] && $quiz->show_description_right_answer() ) || ( ! $question['correct'] && $quiz->show_description_wrong_answer() ) ) {
+										echo '<li><span class="llms-quiz-summary-label clarification">' .
+										     '<strong class="answer_clarification">' .
+										     __( 'Clarification:', 'yoastcom' ) .
+										     '</strong><br>' .
+										     wpautop( trim( $options[ $question['answer'] ]['option_description'] ) ) .
+										     '</span></li>';
 									}
 								}
 								?>


### PR DESCRIPTION
fixes https://github.com/Yoast/yoast.academy/issues/120

**How to test:**
- Make a new lesson.
- Make a new course.
- Make a new quiz and select all the checkboxes.
- Make a question with 3 answers: two without a description and one with a description.
- Link the lesson, course, quiz and question together in the admin interface.
- Go to the quiz in the front-end.
- Start the quiz.
- Choose a wrong answer and check if a description is shown if a description has been set.
- Restart the quiz.
- Choose a wrong answer and check if a description is not shown if a description has not been set.
- Restart the quiz.
- Choose a correct answer and check if a description is shown if a description has been set or not shown if a description has not been set.

Also fixes a strange bug when you finish the quiz and start the same quiz in another tab. If you now refresh the first tab, you always have the quiz wrong, because the quiz doesn't know anymore which answer you have selected.